### PR TITLE
Fix issue #52: added border styling to Bubble52

### DIFF
--- a/src/components/bubbles/Bubble52.js
+++ b/src/components/bubbles/Bubble52.js
@@ -9,7 +9,7 @@ const Bubble52 = ({ title = "button - 52" }) => {
       <div className="absolute inset-0 w-24 h-24 rounded-full bg-gradient-to-r from-red-500 to-orange-500 opacity-0 group-hover:opacity-30 scale-100 group-hover:scale-[2] transition-all duration-600 ease-out blur-sm delay-200"></div>
       
       {/* Main bubble */}
-      <div className="relative z-10 bg-gradient-to-br from-red-700 to-red-900 w-24 h-24 rounded-full shadow-xl hover:shadow-2xl transition-all duration-500 ease-out hover:scale-110 flex items-center justify-center group-hover:animate-pulse">
+      <div className="relative z-10 bg-gradient-to-br from-red-700 to-red-900 w-24 h-24 rounded-full shadow-xl hover:shadow-2xl transition-all duration-500 ease-out hover:scale-110 flex items-center justify-center group-hover:animate-pulse border-4 border-orange-400">
         <span className="text-white text-xs font-bold text-center px-2 drop-shadow-lg">{title}</span>
         
         {/* Inner sparkle effect */}


### PR DESCRIPTION
## 📝 Description
Added border styling to Bubble52 component as requested in the issue. The main bubble now has a 4px orange border that complements the existing red-orange gradient design.

*Issue ID:* #52

---

### 🔍 Changes Made
- [ ] Updated dependencies  
- [ ] Added/modified scripts  
- [x] UI changes  
- [ ] API changes  
- [ ] Database changes  
- [ ] Other (specify below)

---

### 🖼 Screenshots / UI Updates
N/A - Border styling adds a 4px orange border around the main bubble element.

---

### ✅ Checklist
- [x] My code follows the project's coding standards  
- [x] Linked the correct issue ID  
- [ ] Added necessary documentation (if applicable)  
- [x] Tested changes locally  
- [ ] Updated/added relevant tests  
- [x] No new warnings/errors introduced  

---

### 🚀 Additional Notes
- Added `border-4` and `border-orange-400` Tailwind classes to the main bubble div
- Border color (orange-400) matches the component's existing color scheme
- Only modified the file specified in the issue: `src/components/bubbles/Bubble52.js`